### PR TITLE
fix: add libgirepository-1.0-1 to the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,6 +86,7 @@ RUN \
     libldap-common \
     libcairo-gobject2 \
     libenchant-2-2 \
+    libgirepository-1.0-1 \
     "python${PYVERSION}-dev" \
     unzip \
     xz-utils \


### PR DESCRIPTION
It seems to be no longer pulled in automatically by gir packages.

<!--
♥ Thank you for submitting a pull request. ♥

We will review it in a timely manner, but please follow the CI checks to see
any problems it might discover.

Want to make a perfect pull request?

• Keep the pull request reasonably sized. Creating more pull request is sometimes better.
• Describe what the pull request does and what issues it does address.
• Ensure that lint and unit tests pass.
• Add tests that prove that the fix is effective or that the new feature works.
• Describe any new features or changed behavior in the documentation.
-->
