### PR TITLE
fix: don't create an empty ~/.ssh/authorized_keys file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN \
   userdel --remove ubuntu \
   && useradd --uid 1000 --shell /bin/sh --user-group weblate --groups root,tty \
   && mkdir -p /home/weblate/.ssh \
-  && touch /home/weblate/.ssh/authorized_keys \
   && chown -R weblate:weblate /home/weblate \
   && chmod 700 /home/weblate/.ssh \
   && install -d -o weblate -g weblate -m 755 /app/data \


### PR DESCRIPTION
Container platform runtime security solutions alert on mutating this file.
